### PR TITLE
Improve resilience to exceptions thrown during stream processing

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterStream.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterStream.java
@@ -660,6 +660,8 @@ public final class TwitterStream extends TwitterOAuthSupportBaseImpl {
                                         logger.warn(e.getMessage());
                                     }
                                 }
+                            } catch (Exception e) {
+                              logger.warn("Unhandled exception during stream processing: " + e);
                             }
                         }
                     }


### PR DESCRIPTION
We see an occasional problem during stream processing where AbstractStreamImplementation.handleNextElement will throw a NumberFormatException during parsing. Unfortunately, this completely kills the thread. This is definitely a result of bad data upstream, but twitter4j should be more resilient to this type of error.

Here's the stack trace we see (based off of 2.1.6):

Exception in thread "Twitter Stream Handling Thread[Receiving stream]" java.lang.NumberFormatException: For input string: "4294967295"
       at java.lang.NumberFormatException.forInputString(NumberFormatException.java:48)
       at java.lang.Integer.parseInt(Integer.java:461)
       at java.lang.Integer.valueOf(Integer.java:554)
       at twitter4j.internal.util.ParseUtil.getInt(ParseUtil.java:120)
       at twitter4j.UserJSONImpl.init(UserJSONImpl.java:103)
       at twitter4j.UserJSONImpl.<init>(UserJSONImpl.java:86)
       at twitter4j.StatusJSONImpl.init(StatusJSONImpl.java:99)
       at twitter4j.StatusJSONImpl.<init>(StatusJSONImpl.java:82)
       at twitter4j.StatusStreamImpl.handleNextElement(StatusStreamImpl.java:99)
       at twitter4j.StatusStreamImpl.next(StatusStreamImpl.java:79)
       at twitter4j.TwitterStream$StreamHandlingThread.run(TwitterStream.java:462)
