### PR TITLE
Strangeness around the TwitterStreamConsumer's closed flag

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterStream.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterStream.java
@@ -784,13 +784,16 @@ public final class TwitterStream extends TwitterOAuthSupportBaseImpl {
 
         public synchronized void close() {
             setStatus("[Disposing thread]");
-            if (null != stream) {
-                try {
-                    stream.close();
-                } catch (IOException ignore) {
-                }
+            try { 
+              if (null != stream) {
+                  try {
+                      stream.close();
+                  } catch (IOException ignore) {
+                  }
+              }
+            } finally {
+              closed = true;
             }
-            closed = true;
         }
 
         private void setStatus(String message) {


### PR DESCRIPTION
Hiyah,

I've been testing the current snapshot fairly heavily for a view to use in production and I'm running into a strange error, it seems as though the TwitterStreamConsumer's run() method sometimes doesn't exit correctly after a call to 'close'.

The thread has the name '[Disposing thread] ...'  suggesting that 'close()' was successfully called, and the debugger reports the value of 'closed' as true, but unless I _manually_ step-over the while(!closed) condition the loop appears to  cycle in-definitely.  A bit puzzling :(   Please find attached two patches that may help, I certainly don't think they'll cause issues.

When I suspend the thread in the debugger the value of 'closed' is correctly set 

Many Thanks
 -CJ.
