### PR TITLE
support list calls without owner screenname

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/AsyncTwitter.java
+++ b/twitter4j-core/src/main/java/twitter4j/AsyncTwitter.java
@@ -924,6 +924,17 @@ public class AsyncTwitter extends TwitterOAuthSupportBase
     /**
      * {@inheritDoc}
      */
+    public void getUserListStatuses(final int listOwnerId, final int id, final Paging paging) {
+        getDispatcher().invokeLater(new AsyncTask(USER_LIST_STATUSES, listener) {
+            public void invoke(TwitterListener listener) throws TwitterException {
+                listener.gotUserListStatuses(twitter.getUserListStatuses(listOwnerId, id, paging));
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void getUserListMemberships(final String listMemberScreenName, final long cursor) {
         getDispatcher().invokeLater(new AsyncTask(USER_LIST_MEMBERSHIPS, listener) {
             public void invoke(TwitterListener listener) throws TwitterException {
@@ -974,6 +985,17 @@ public class AsyncTwitter extends TwitterOAuthSupportBase
         getDispatcher().invokeLater(new AsyncTask(LIST_MEMBERS, listener) {
             public void invoke(TwitterListener listener) throws TwitterException {
                 listener.gotUserListMembers(twitter.getUserListMembers(listOwnerScreenName, listId, cursor));
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void getUserListMembers(final int listOwnerId, final int listId, final long cursor) {
+        getDispatcher().invokeLater(new AsyncTask(LIST_MEMBERS, listener) {
+            public void invoke(TwitterListener listener) throws TwitterException {
+                listener.gotUserListMembers(twitter.getUserListMembers(listOwnerId, listId, cursor));
             }
         });
     }

--- a/twitter4j-core/src/main/java/twitter4j/Twitter.java
+++ b/twitter4j-core/src/main/java/twitter4j/Twitter.java
@@ -937,6 +937,15 @@ public class Twitter extends TwitterOAuthSupportBaseImpl
     /**
      * {@inheritDoc}
      */
+    public ResponseList<Status> getUserListStatuses(int listOwnerId, int id, Paging paging) throws TwitterException {
+        return StatusJSONImpl.createStatusList(http.get(conf.getRestBaseURL() + listOwnerId +
+                "/lists/" + id + "/statuses.json", mergeParameters(paging.asPostParameterArray(Paging.SMCP, Paging.PER_PAGE)
+                , INCLUDE_ENTITIES), auth));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, long cursor) throws TwitterException {
         ensureAuthorizationEnabled();
         return UserListJSONImpl.createPagableUserListList(http.get(conf.getRestBaseURL() +
@@ -980,6 +989,17 @@ public class Twitter extends TwitterOAuthSupportBaseImpl
         ensureAuthorizationEnabled();
         return UserJSONImpl.createPagableUserList(http.get(conf.getRestBaseURL() +
                 listOwnerScreenName + "/" + listId + "/members.json?include_entities="
+                + conf.isIncludeEntitiesEnabled() + "&cursor=" + cursor, auth));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public PagableResponseList<User> getUserListMembers(int listOwnerId, int listId
+            , long cursor) throws TwitterException {
+        ensureAuthorizationEnabled();
+        return UserJSONImpl.createPagableUserList(http.get(conf.getRestBaseURL() +
+                listOwnerId + "/" + listId + "/members.json?include_entities="
                 + conf.isIncludeEntitiesEnabled() + "&cursor=" + cursor, auth));
     }
 

--- a/twitter4j-core/src/main/java/twitter4j/api/ListMembersMethods.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListMembersMethods.java
@@ -49,6 +49,20 @@ public interface ListMembersMethods {
 	PagableResponseList<User> getUserListMembers(String listOwnerScreenName, int listId, long cursor)
 			throws TwitterException;
 
+    /**
+	 * Returns the members of the specified list.
+	 * <br>This method calls http://api.twitter.com/1/[user]/[list_id]/members.json
+     * @param listOwnerId The id of the list owner
+	 * @param listId The id of the list
+	 * @param cursor Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+	 * @return the members of the specified list.
+	 * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="http://dev.twitter.com/doc/get/:user/:list_id/members">GET :user/:list_id/members | dev.twitter.com</a>
+	 * @since Twitter4J 2.1.0
+	 */
+	PagableResponseList<User> getUserListMembers(int listOwnerId, int listId, long cursor)
+			throws TwitterException;
+
 	/**
 	 * Adds a member to a list. The authenticated user must own the list to be able to add members to it. Lists are limited to having 500 members.
 	 * <br>This method calls http://api.twitter.com/1/[listOwner]/[listId]/members.json

--- a/twitter4j-core/src/main/java/twitter4j/api/ListMembersMethodsAsync.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListMembersMethodsAsync.java
@@ -42,6 +42,17 @@ public interface ListMembersMethodsAsync {
     void getUserListMembers(String listOwnerScreenName, int listId, long cursor);
 
     /**
+     * Returns the members of the specified list.
+     * <br>This method calls http://api.twitter.com/1/[user]/[list_id]/members.json
+     * @param listOwnerId The id of the list owner
+     * @param listId The id of the list
+     * @param cursor Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @see <a href="http://dev.twitter.com/doc/get/:user/:list_id/members">GET :user/:list_id/members | dev.twitter.com</a>
+     * @since Twitter4J 2.1.1
+     */
+    void getUserListMembers(int listOwnerId, int listId, long cursor);
+
+    /**
      * Adds a member to a list. The authenticated user must own the list to be able to add members to it. Lists are limited to having 500 members.
      * <br>This method calls http://api.twitter.com/1/[listOwner]/[listId]/members.json
      * @param listId The id of the list.

--- a/twitter4j-core/src/main/java/twitter4j/api/ListMethods.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListMethods.java
@@ -123,6 +123,20 @@ public interface ListMethods {
     ResponseList<Status> getUserListStatuses(String listOwnerScreenName, int id, Paging paging)
             throws TwitterException;
 
+   /**
+     * Show tweet timeline for members of the specified list.
+     * <br>http://api.twitter.com/1/user/lists/list_id/statuses.json
+     *
+     * @param listOwnerId         The id of the list owner
+     * @param id                  The id of the list to delete
+     * @param paging              controls pagination. Supports since_id, max_id, count and page parameters.
+     * @return list of statuses for members of the specified list
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="http://dev.twitter.com/doc/get/:user/lists/:id/statuses">GET :user/lists/:id/statuses | dev.twitter.com</a>
+     * @since Twitter4J 2.1.0
+     */
+    ResponseList<Status> getUserListStatuses(int listOwnerId, int id, Paging paging)
+            throws TwitterException;
     /**
      * List the lists the specified user has been added to.
      * <br>This method calls http://api.twitter.com/1/:user/lists/memberships.json

--- a/twitter4j-core/src/main/java/twitter4j/api/ListMethodsAsync.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListMethodsAsync.java
@@ -105,6 +105,18 @@ public interface ListMethodsAsync {
     void getUserListStatuses(String listOwnerScreenName, int id, Paging paging);
 
     /**
+     * Show tweet timeline for members of the specified list.
+     * <br>http://api.twitter.com/1/user/lists/list_id/statuses.json
+     *
+     * @param listOwnerId The screen name of the list owner
+     * @param id                  The id of the list to delete
+     * @param paging              controls pagination. Supports since_id, max_id, count and page parameters.
+     * @see <a href="http://dev.twitter.com/doc/get/:user/lists/:id/statuses">GET :user/lists/:id/statuses | dev.twitter.com</a>
+     * @since Twitter4J 2.1.1
+     */
+    void getUserListStatuses(int listOwnerId, int id, Paging paging);
+
+    /**
      * List the lists the specified user has been added to.
      * <br>This method calls http://api.twitter.com/1/:user/lists/memberships.json
      *

--- a/twitter4j-core/src/test/java/twitter4j/TwitterTest.java
+++ b/twitter4j-core/src/test/java/twitter4j/TwitterTest.java
@@ -271,6 +271,10 @@ public class TwitterTest extends TwitterTestBase {
         if (statuses.size() > 0) {
             assertEquals(statuses.get(0), DataObjectFactory.createStatus(DataObjectFactory.getRawJSON(statuses.get(0))));
         }
+        statuses = twitter1.getUserListStatuses(id1.id, userList.getId(), new Paging());
+        if (statuses.size() > 0) {
+            assertEquals(statuses.get(0), DataObjectFactory.createStatus(DataObjectFactory.getRawJSON(statuses.get(0))));
+        }
         assertNotNull(DataObjectFactory.getRawJSON(statuses));
         assertNull(DataObjectFactory.getRawJSON(userList));
         assertNotNull(statuses);
@@ -307,6 +311,11 @@ public class TwitterTest extends TwitterTestBase {
         // http://code.google.com/p/twitter-api/issues/detail?id=1301
 //        assertEquals(userList.getMemberCount(), users.size());
         assertTrue(0 < users.size());// workaround issue 1301
+
+        users = twitter1.getUserListMembers(id1.id, userList.getId(), -1);
+        assertEquals(users.get(0), DataObjectFactory.createUser(DataObjectFactory.getRawJSON(users.get(0))));
+        assertNotNull(DataObjectFactory.getRawJSON(users));
+        assertTrue(0 < users.size());
 
         userList = twitter1.deleteUserListMember(userList.getId(), id2.id);
         assertNotNull(DataObjectFactory.getRawJSON(userList));


### PR DESCRIPTION
added 2 versions of list methods which take owner id so don't need owner screenname.
