### PR TITLE
User stream fix

### DIFF
--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -218,7 +218,7 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
             if (null != track) {
                 params.add(new HttpParameter("track", T4JInternalStringUtil.join(track)));
             }
-            return new UserStreamImpl(getDispatcher(), http.post(conf.getUserStreamBaseURL() + "dao/user.json"
+            return new UserStreamImpl(getDispatcher(), http.post(conf.getUserStreamBaseURL() + "user.json"
                     , params.toArray(new HttpParameter[params.size()])
                     , auth), conf);
         } catch (IOException e) {


### PR DESCRIPTION
The current (2.2.0) userstream url appears to have an extraneous '/dao/' segment in its path.  I believe this not to be correct (userstreams are broken for me without this patch) :(
