### PR TITLE
More meaningful exception when access token format is wrong

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/auth/AccessToken.java
+++ b/twitter4j-core/src/main/java/twitter4j/auth/AccessToken.java
@@ -43,7 +43,12 @@ public class AccessToken extends OAuthToken implements java.io.Serializable {
 
     public AccessToken(String token, String tokenSecret) {
         super(token, tokenSecret);
-        String sUserId = token.substring(0, token.indexOf("-"));
+        String sUserId;
+        try {
+        sUserId = token.substring(0, token.indexOf("-"));
+        } catch (IndexOutOfBoundsException e) {
+             throw new IllegalArgumentException("Invalid access token format.");
+        }
         if (sUserId != null) userId = Long.parseLong(sUserId);
     }
 


### PR DESCRIPTION
See http://twitter4j.org/jira/browse/TFJ-570.
