### PR TITLE
Android can handle TCP timeouts so keep isJDK14orEarlier as it should

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/internal/http/HttpClientImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/internal/http/HttpClientImpl.java
@@ -57,7 +57,6 @@ public class HttpClientImpl extends HttpClientBase implements HttpClient, HttpRe
                 isJDK14orEarlier = 1.5d > Double.parseDouble(versionStr);
             }
             if (ConfigurationContext.getInstance().isDalvik()) {
-                isJDK14orEarlier = false;
                 // quick and dirty workaround for TFJ-296
                 // it must be an Android/Dalvik/Harmony side issue!!!!
                 System.setProperty("http.keepAlive", "false");


### PR DESCRIPTION
isJDK14orEarlier is responsible for using the TCP timeout that works on Android and is very welcome
