### PR TITLE
the search API should use SSL as configured by the user too

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
@@ -470,6 +470,9 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         if (DEFAULT_OAUTH_REQUEST_TOKEN_URL.equals(fixURL(false, oAuthRequestTokenURL))) {
             this.oAuthRequestTokenURL = fixURL(useSSL, oAuthRequestTokenURL);
         }
+        if (DEFAULT_SEARCH_BASE_URL.equals(fixURL(false, searchBaseURL))) {
+            this.searchBaseURL = fixURL(useSSL, searchBaseURL);
+        }
     }
 
     public String getSearchBaseURL() {


### PR DESCRIPTION
This one is needed in Plume so that when the user selects SSL he is sure to use SSL for everything
