### PR TITLE
Twitter only send 20 retweets at most

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -488,7 +488,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     public ResponseList<Status> getRetweets(long statusId) throws TwitterException {
         ensureAuthorizationEnabled();
         return factory.createStatusList(get(conf.getRestBaseURL()
-                + "statuses/retweets/" + statusId + ".json?count=100&include_entities="
+                + "statuses/retweets/" + statusId + ".json?count=20&include_entities="
                 + conf.isIncludeEntitiesEnabled()));
     }
 


### PR DESCRIPTION
When testing we found out the actual max Twitter honors is 20 retweets per request
