### PR TITLE
Added query parameter to filter results from geo/search by name

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/GeoQuery.java
+++ b/twitter4j-core/src/main/java/twitter4j/GeoQuery.java
@@ -71,8 +71,8 @@ public final class GeoQuery implements java.io.Serializable {
         return query
     }
     
-    public String setQuery(String query) {
-        return this.query
+    public void setQuery(String query) {
+        this.query = query;
     }
 
     public String getIp() {


### PR DESCRIPTION
I needed to be able to search for poi in geo/search, but I can't extend the GeoQuery.class because it is final. I added a get and set function as well as modified toString to add a query param to send to geo/search.
