### PR TITLE
Use the default locale when initializing SimpleDateFormat.

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/internal/util/z_T4JInternalParseUtil.java
+++ b/twitter4j-core/src/main/java/twitter4j/internal/util/z_T4JInternalParseUtil.java
@@ -111,7 +111,7 @@ public final class z_T4JInternalParseUtil {
         SimpleDateFormat sdf = formatMap.get().get(format);
         if (null == sdf) {
             sdf = new SimpleDateFormat(format, Locale.US);
-            sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
             formatMap.get().put(format, sdf);
         }
         try {


### PR DESCRIPTION
If we pass `Locale.ENGLISH` to `SimpleDateFormat` on Android, it causes a significant slowdown (old phones freeze while Twitter4J is parsing data).

Taking a look at the log, we can see a lot of:
```I/global  (25155): Loaded time zone names for en in 5215ms.
I/global  (25155): Loaded time zone names for en in 5729ms.
I/global  (25155): Loaded time zone names for en in 6015ms.
I/global  (25155): Loaded time zone names for en in 6051ms.
I/global  (25155): Loaded time zone names for en in 6010ms.
I/global  (25155): Loaded time zone names for en in 6130ms.
I/global  (25155): Loaded time zone names for en in 6429ms.
I/global  (25155): Loaded time zone names for en in 6476ms.
I/global  (25155): Loaded time zone names for en in 6541ms.
I/global  (25155): Loaded time zone names for en in 6767ms.
I/global  (25155): Loaded time zone names for en in 6916ms.
I/global  (25155): Loaded time zone names for en in 7333ms.
I/global  (25155): Loaded time zone names for en in 7615ms.
I/global  (25155): Loaded time zone names for en in 8929ms.
I/global  (25155): Loaded time zone names for en in 5125ms.
I/global  (25155): Loaded time zone names for en in 5080ms.
I/global  (25155): Loaded time zone names for en in 5805ms.
I/global  (25155): Loaded time zone names for en in 5702ms.
I/global  (25155): Loaded time zone names for en in 5353ms.
I/global  (25155): Loaded time zone names for en in 6353ms.
I/global  (25155): Loaded time zone names for en in 5243ms.
I/global  (25155): Loaded time zone names for en in 5758ms.
I/global  (25155): Loaded time zone names for en in 6565ms.
I/global  (25155): Loaded time zone names for en in 6604ms.
I/global  (25155): Loaded time zone names for en in 5487ms.
I/global  (25155): Loaded time zone names for en in 6069ms.
I/global  (25155): Loaded time zone names for en in 6632ms.
I/global  (25155): Loaded time zone names for en in 4415ms.

```

Allowing SimpleDateFormat to use the default locale (by *not* passing in `Locale.ENGLIGH` fixes this problem, making Twitter4J noticeably faster.

Could this be included in the next release?

We should also consider alternatives into caching `df`. There are only a few possible formats and it might speed things up as well.

Thanks.
```
