### PR TITLE
Better fix for TFJ-619, support current_user_retweet field in Status object.

### DIFF
--- a/twitter4j-appengine/src/main/java/twitter4j/internal/json/LazyStatus.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/internal/json/LazyStatus.java
@@ -230,6 +230,17 @@ final class LazyStatus implements twitter4j.Status {
     public boolean isRetweetedByMe() {
         return getTarget().isRetweetedByMe();
     }
+    
+    /**
+     * Returns the authenticating user's retweet of this tweet, or null when the tweet was created
+     * before this feature was enabled. Note that the available information is restricted to its id.
+     *
+     * @return the authenticating user's retweet of this tweet
+     * @since Twitter4J 2.2.6
+     */
+    public Status getMyRetweet() {
+    	return getTarget().getMyRetweet();
+    }
 
 
     /**

--- a/twitter4j-core/src/main/java/twitter4j/Status.java
+++ b/twitter4j-core/src/main/java/twitter4j/Status.java
@@ -154,6 +154,15 @@ public interface Status extends Comparable<Status>, TwitterResponse,
      * @since Twitter4J 2.1.4
      */
     boolean isRetweetedByMe();
+    
+    /**
+     * Returns the authenticating user's retweet of this tweet, or null when the tweet was created
+     * before this feature was enabled. Note that the available information is restricted to its id.
+     *
+     * @return the authenticating user's retweet of this tweet
+     * @since Twitter4J 2.2.6
+     */
+    Status getMyRetweet();
 
     /**
      * Returns the annotations, or null if no annotations are associated with this status.

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -421,7 +421,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
      * {@inheritDoc}
      */
     public Status showStatus(long id) throws TwitterException {
-        return factory.createStatus(get(conf.getRestBaseURL() + "statuses/show/" + id + ".json?include_entities="
+        return factory.createStatus(get(conf.getRestBaseURL() + "statuses/show/" + id + ".json?include_my_retweet=1&include_entities="
                 + conf.isIncludeEntitiesEnabled()));
     }
 

--- a/twitter4j-core/src/main/java/twitter4j/internal/json/StatusJSONImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/internal/json/StatusJSONImpl.java
@@ -53,7 +53,6 @@ import static twitter4j.internal.util.z_T4JInternalParseUtil.getUnescapedString;
     private GeoLocation geoLocation = null;
     private Place place = null;
     private long retweetCount;
-    private boolean wasRetweetedByMe;
 
     private String[] contributors = null;
     private long[] contributorsIDs;
@@ -187,7 +186,6 @@ import static twitter4j.internal.util.z_T4JInternalParseUtil.getUnescapedString;
         if (!json.isNull("current_user_retweet")) {
             try {
                 myRetweetedStatus = new StatusJSONImpl(json.getJSONObject("current_user_retweet"));
-                wasRetweetedByMe = true;
             } catch (JSONException ignore) {
                 ignore.printStackTrace();
                 logger.warn("failed to parse current_user_retweet:" + json);
@@ -346,7 +344,14 @@ import static twitter4j.internal.util.z_T4JInternalParseUtil.getUnescapedString;
      * {@inheritDoc}
      */
     public boolean isRetweetedByMe() {
-        return wasRetweetedByMe;
+        return myRetweetedStatus != null;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Status getMyRetweet() {
+    	return myRetweetedStatus;
     }
 
     /**
@@ -436,7 +441,7 @@ import static twitter4j.internal.util.z_T4JInternalParseUtil.getUnescapedString;
                 ", geoLocation=" + geoLocation +
                 ", place=" + place +
                 ", retweetCount=" + retweetCount +
-                ", wasRetweetedByMe=" + wasRetweetedByMe +
+                ", myRetweetedStatus=" + myRetweetedStatus +
                 ", contributors=" + (contributorsIDs == null ? null : Arrays.asList(contributorsIDs)) +
                 ", annotations=" + annotations +
                 ", retweetedStatus=" + retweetedStatus +


### PR DESCRIPTION
Hello,

This improves on the already existing fix to TFJ-619.

Since current_user_retweet contains an actual tweet, it's better to store that information instead of just keeping record if it exists. This is specially useful when we need to know the id of our retweet and all we have the the Status object (or its id) of the tweet we retweeted.
