### PR TITLE
Potential patch for onException behavior - to remove wait time before onException called and handle 403/406 response

### DIFF
--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -498,11 +498,17 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
                             if (te.getStatusCode() == FORBIDDEN) {
                                 logger.warn("This account is not in required role. ", te.getMessage());
                                 closed = true;
+                                for (StreamListener statusListener : streamListeners) {
+                                    statusListener.onException(te);
+                                }                                                        
                                 break;
                             }
                             if (te.getStatusCode() == NOT_ACCEPTABLE) {
                                 logger.warn("Parameter not accepted with the role. ", te.getMessage());
                                 closed = true;
+                                for (StreamListener statusListener : streamListeners) {
+                                    statusListener.onException(te);
+                                }                                                        
                                 break;
                             }
                             connected = false;
@@ -531,6 +537,9 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
                                 }
                             }
                         }
+                        for (StreamListener statusListener : streamListeners) {
+                            statusListener.onException(te);
+                        }                        
                         // there was a problem establishing the connection, or the connection closed by peer
                         if (!closed) {
                             // wait for a moment not to overload Twitter API
@@ -544,9 +553,6 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
                         }
                         stream = null;
                         logger.debug(te.getMessage());
-                        for (StreamListener statusListener : streamListeners) {
-                            statusListener.onException(te);
-                        }
                         connected = false;
                     }
                 }
@@ -593,7 +599,7 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
                 closed = true;
             }
         }
-
+                                        
         private void setStatus(String message) {
             String actualMessage = NAME + message;
             setName(actualMessage);


### PR DESCRIPTION
Pull request for issues related to onException behavior:

1) onException method for listeners is not called right away, it is called after Thread.sleep is issued 
(this does not seem to be related to connection time as twitter4j has exception but only notifies 
listeners after Thread.sleep returns).

2) Behavior for 403 and 406 responses - onException is not called at all, and no exception is thrown either.  
In this case client would not be able to detect error.  

With this pull requests, there is no wait time for #1, and onException is properly called for #2.
