### PR TITLE
add support for the new "possibly_sensitive" field TFJ-683

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/Status.java
+++ b/twitter4j-core/src/main/java/twitter4j/Status.java
@@ -154,6 +154,14 @@ public interface Status extends Comparable<Status>, TwitterResponse,
      */
     boolean isRetweetedByMe();
 
+     /**
+     * Returns true if the status contains a link that is identified as sensitive.
+     *
+     * @return whether the status contains sensitive links
+     * @since Twitter4J 3.0.0
+     */
+    boolean isPossiblySensitive();
+
     /**
      * Returns the annotations, or null if no annotations are associated with this status.
      *

--- a/twitter4j-core/src/main/java/twitter4j/internal/json/StatusJSONImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/internal/json/StatusJSONImpl.java
@@ -51,6 +51,7 @@ import static twitter4j.internal.util.z_T4JInternalParseUtil.*;
     private Place place = null;
     private long retweetCount;
     private boolean wasRetweetedByMe;
+    private boolean isPossiblySensitive;
 
     private String[] contributors = null;
     private long[] contributorsIDs;
@@ -94,6 +95,7 @@ import static twitter4j.internal.util.z_T4JInternalParseUtil.*;
         isFavorited = getBoolean("favorited", json);
         inReplyToScreenName = getUnescapedString("in_reply_to_screen_name", json);
         retweetCount = getLong("retweet_count", json);
+        isPossiblySensitive = getBoolean("possibly_sensitive", json);
         try {
             if (!json.isNull("user")) {
                 user = new UserJSONImpl(json.getJSONObject("user"));
@@ -374,6 +376,14 @@ import static twitter4j.internal.util.z_T4JInternalParseUtil.*;
      * {@inheritDoc}
      */
     @Override
+    public boolean isPossiblySensitive() {
+        return isPossiblySensitive;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public UserMentionEntity[] getUserMentionEntities() {
         return userMentionEntities;
     }
@@ -462,6 +472,7 @@ import static twitter4j.internal.util.z_T4JInternalParseUtil.*;
                 ", place=" + place +
                 ", retweetCount=" + retweetCount +
                 ", wasRetweetedByMe=" + wasRetweetedByMe +
+                ", isPossiblySensitive=" + isPossiblySensitive +
                 ", contributors=" + (contributorsIDs == null ? null : Arrays.asList(contributorsIDs)) +
                 ", annotations=" + annotations +
                 ", retweetedStatus=" + retweetedStatus +


### PR DESCRIPTION
This field has been added recently to Statuses: see https://dev.twitter.com/docs/platform-objects/tweets 

Extract from API page: https://dev.twitter.com/docs/platform-objects/tweets 
"possibly_sensitive (Boolean Nullable) 
This field only surfaces when a tweet contains a link. The meaning of the field doesn't pertain to the tweet content itself, but instead it is an indicator that the URL contained in the tweet may contain content or media identified as sensitive content."
