### PR TITLE
Fix for bug in lookupUsers

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,7 @@ marr-masaaki <marr fiveflavors at gmail.com> @marr
 matsumo <matsumo at ce.ns0.it>
 Max Penet <m at qbits.cc> @mpenet
 Mocel <docel77 at gmail.com> @Mocel
+Myyk Seok <myyk.seok at gmail.com> @myyk
 Naoya Hatayama <applepedlar at gmail.com> @ApplePedlar
 Ngoc Dao <ngocdaothanh@gmail.com> @ngocdaothanh
 Nobutoshi Ogata <n-ogata at cnt.biglobe.co.jp> @nobu666

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -813,7 +813,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
      */
     @Override
     public ResponseList<User> lookupUsers(String[] screenNames) throws TwitterException {
-        return factory.createUserList(post(conf.getRestBaseURL() + "users/lookup.json"
+        return factory.createUserList(get(conf.getRestBaseURL() + "users/lookup.json"
                 , new HttpParameter[]{new HttpParameter("screen_name", z_T4JInternalStringUtil.join(screenNames))}));
     }
 


### PR DESCRIPTION
Currently lookupUsers is using a POST, when it is really supposed to be a GET.  Using it the way it is now will produce an exception like this:

Error processing your OAuth request: Read-only application cannot POST code - 89
