### PR TITLE
Using API1.1 verify credentials URL when upload image to Lockerz.

### DIFF
--- a/twitter4j-media-support/src/main/java/twitter4j/media/PlixiUpload.java
+++ b/twitter4j-media-support/src/main/java/twitter4j/media/PlixiUpload.java
@@ -56,9 +56,9 @@ class PlixiUpload extends AbstractImageUploadImpl {
 
     @Override
     protected void preUpload() throws TwitterException {
-        String verifyCredentialsAuthorizationHeader = generateVerifyCredentialsAuthorizationHeader(TWITTER_VERIFY_CREDENTIALS_XML_V1);
+        String verifyCredentialsAuthorizationHeader = generateVerifyCredentialsAuthorizationHeader(TWITTER_VERIFY_CREDENTIALS_JSON_V1_1);
 
-        headers.put("X-Auth-Service-Provider", TWITTER_VERIFY_CREDENTIALS_XML_V1);
+        headers.put("X-Auth-Service-Provider", TWITTER_VERIFY_CREDENTIALS_JSON_V1_1);
         headers.put("X-Verify-Credentials-Authorization", verifyCredentialsAuthorizationHeader);
 
         if (null == apiKey) {


### PR DESCRIPTION
LockerzがAPI1.1に対応したので、T4Jのほうも1.1のURLを使うよう変更しました。
良ければ本家にマージお願いします。
