### PR TITLE
Fixed dropped Twitter error code 89 when using a revoked token

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/internal/http/HttpResponseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/internal/http/HttpResponseImpl.java
@@ -31,7 +31,21 @@ public class HttpResponseImpl extends HttpResponse {
     HttpResponseImpl(HttpURLConnection con, HttpClientConfiguration conf) throws IOException {
         super(conf);
         this.con = con;
-        this.statusCode = con.getResponseCode();
+        try {
+          this.statusCode = con.getResponseCode();
+        } catch (IOException e) {
+          /*
+           * If the user has revoked the access token in use, then Twitter naughtily returns a 401 with no "WWW-Authenticate" header.
+           *
+           * This causes an IOException in the getResponseCode() method call. See https://dev.twitter.com/issues/1114
+           * This call can, however, me made a second time without exception.
+           */
+          if ("Received authentication challenge is null".equals(e.getMessage())) {
+            this.statusCode = con.getResponseCode();
+          } else {
+            throw e;
+          }
+        }
         if (null == (is = con.getErrorStream())) {
             is = con.getInputStream();
         }


### PR DESCRIPTION
When the user revokes an app access token, subsequent attempts to use the token result in an HTTP 401 response that omits the WWW-Authenticate header, required for HTTP 1.1 as detailed in RFC 2616.  This causes an IOException from HttpUrlConnection, and a general TwitterException occurs that obscures the error code 89 (Indeed, the response body is not parsed before the IOException occurs).

See https://dev.twitter.com/issues/1114
