### PR TITLE
check that controlURI is set and don't wait longer than needed

### DIFF
--- a/twitter4j-stream/src/main/java/twitter4j/StreamController.java
+++ b/twitter4j-stream/src/main/java/twitter4j/StreamController.java
@@ -61,9 +61,14 @@ public class StreamController {
     void ensureControlURISet() throws TwitterException {
         synchronized (lock) {
             try {
-                lock.wait(30000);
-                throw new TwitterException("timed out for control uri to be ready");
-            } catch (InterruptedException ignored) {
+		int waits = 0;
+                while (controlURI == null) {
+                    lock.wait(1000);
+                    waits++;
+                    
+                    if (waits > 29) throw new TwitterException("timed out for control uri to be ready");
+                }           
+            } catch (InterruptedException e) {
             }
         }
     }


### PR DESCRIPTION
This was never checking the controlURI variable and always caused unneeded 30 second waits.
