### PR TITLE
Removed reference to Control Stream URI once the Site Stream is disconnected

### DIFF
--- a/twitter4j-stream/src/main/java/twitter4j/SiteStreamsImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/SiteStreamsImpl.java
@@ -75,6 +75,11 @@ final class SiteStreamsImpl extends StatusStreamBase {
         return line.substring(userIdEnd + 11, line.length() - 1);
     }
 
+    @Override
+    protected void onClose() {
+        cs.setControlURI(null);
+    }
+
     private static final ThreadLocal<Long> forUser =
             new ThreadLocal<Long>() {
                 @Override

--- a/twitter4j-stream/src/main/java/twitter4j/StatusStreamBase.java
+++ b/twitter4j-stream/src/main/java/twitter4j/StatusStreamBase.java
@@ -185,6 +185,7 @@ abstract class StatusStreamBase implements StatusStream {
             }
             boolean isUnexpectedException = streamAlive;
             streamAlive = false;
+            onClose();
             if (isUnexpectedException) {
                 throw new TwitterException("Stream closed.", ioe);
             }
@@ -291,6 +292,8 @@ abstract class StatusStreamBase implements StatusStream {
         logger.warn("Unhandled event: ", e.getMessage());
     }
 
+    protected abstract void onClose();
+
     public void close() throws IOException {
         streamAlive = false;
         is.close();
@@ -298,6 +301,7 @@ abstract class StatusStreamBase implements StatusStream {
         if (response != null) {
             response.disconnect();
         }
+        onClose();
     }
 
     Status asStatus(JSONObject json) throws TwitterException {

--- a/twitter4j-stream/src/main/java/twitter4j/StatusStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/StatusStreamImpl.java
@@ -44,6 +44,9 @@ class StatusStreamImpl extends StatusStreamBase {
     static final RawStreamListener[] EMPTY = new RawStreamListener[0];
 
     @Override
+    protected void onClose(){}
+
+    @Override
     public void next(StatusListener listener) throws TwitterException {
         handleNextElement(new StatusListener[]{listener}, EMPTY);
     }


### PR DESCRIPTION
When site streams connection is closed, the associated control stream is no longer valid. This removes it from the URI from the handler's StreamController, to prevent unnecessary calls against Twitter's API, while it waits from the new control URI on the reconnect.
