### PR TITLE
Added default constructor for ScopesImpl

### DIFF
--- a/twitter4j-core/src/internal-json/java/twitter4j/ScopesImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/ScopesImpl.java
@@ -27,7 +27,7 @@ public class ScopesImpl implements Scopes {
     
     /* Only for serialization purposes. */
     /*package*/ ScopesImplJSONImpl() {
-
+        this.placeIds = new String[0];
     }
 
     public ScopesImpl(final String[] placeIds) {


### PR DESCRIPTION
A default constructor is needed for serialization purposes. 

See example error that can be thrown by kryo when serializing through storm :

java.lang.RuntimeException: com.esotericsoftware.kryo.KryoException: Class cannot be created (missing no-arg constructor): twitter4j.ScopesImpl Serialization trace: scopes (twitter4j.StatusJSONImpl) 
