### PR TITLE
Fix the conversion of Geometry Point in PlaceJSONImpl

### DIFF
--- a/twitter4j-core/src/internal-json/java/twitter4j/PlaceJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/PlaceJSONImpl.java
@@ -90,7 +90,7 @@ final class PlaceJSONImpl extends TwitterResponseImpl implements Place, java.io.
                 JSONArray array = geometryJSON.getJSONArray("coordinates");
                 if (geometryType.equals("Point")) {
                     geometryCoordinates = new GeoLocation[1][1];
-                    geometryCoordinates[0][0] = new GeoLocation(array.getDouble(0), array.getDouble(1));
+                    geometryCoordinates[0][0] = new GeoLocation(array.getDouble(1), array.getDouble(0));
                 } else if (geometryType.equals("Polygon")) {
                     geometryCoordinates = JSONImplFactory.coordinatesAsGeoLocationArray(array);
                 } else {


### PR DESCRIPTION
Fix the conversion of Geometry Point to `GeoLocation` in `PlaceJSONImpl` - **Latitude and Longitude were in reverse order**.

For example, Twitter HQ ([the example Twitter uses](https://dev.twitter.com/docs/about-geo-place-attributes)) has

``` json
"geometry": {
    "coordinates": [
      -122.400612831116,
      37.7821120598956
    ],
    "type": "Point"
}
```

Longitude `[0]`: -122.400612831116, Latitude `[1]`: 37.7821120598956

The `GeoLocation` constructor accepts (latitude, longitude).

You can also see that in `z_T4JInternalJSONImplFactory.coordinatesAsGeoLocationArray` the correct order is used:

``` java
boundingBox[i][j] = new GeoLocation(coordinate.getDouble(1), coordinate.getDouble(0));
```
