### PR TITLE
Update TwitterStreamConsumer closed flag

### DIFF
--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -613,9 +613,9 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
 
         public synchronized void close() {
             setStatus("[Disposing thread]");
+            closed = true;
             if (stream != null) {
                 try {
-                    closed = true;
                     stream.close();
                 } catch (IOException ignore) {
                 } catch (Exception e) {


### PR DESCRIPTION
Update closed flag even if the stream is not initialized.
This to prevent the consumer thread from running indefinitely, for example when
it’s sleeping and waiting to reconnect after an initial HTTP error.
