### PR TITLE
Synchronize static members intialization in constructor

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -47,6 +47,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     TwitterImpl(Configuration conf, Authorization auth) {
         super(conf, auth);
         INCLUDE_MY_RETWEET = new HttpParameter("include_my_retweet", conf.isIncludeMyRetweetEnabled());
+        synchronized(TwitterImpl.class) {
         HttpParameter[] implicitParams = implicitParamsMap.get(conf);
         String implicitParamsStr = implicitParamsStrMap.get(conf);
         if (implicitParams == null) {
@@ -76,6 +77,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
 
         IMPLICIT_PARAMS = implicitParams;
         IMPLICIT_PARAMS_STR = implicitParamsStr;
+        }
     }
 
     /* Timelines Resources */


### PR DESCRIPTION
There are rare cases of entering an infinite loop when initializing multiple instances of TwitterImpl from multiple threads concurrently.

`implicitParamsStrMap.put(conf, implicitParamsStr);`

Might cause an infinite loop in 

```
        at java.util.HashMap.transfer(HashMap.java:484)
        at java.util.HashMap.resize(HashMap.java:463)
        at java.util.HashMap.addEntry(HashMap.java:755)
        at java.util.HashMap.put(HashMap.java:385)
```

More info about `HashMap.put()` causing an infinite loop can be found here http://stackoverflow.com/q/13695832/1442259
