### PR TITLE
TFJ-806: Read the target fields of 'user_delete' and 'user_suspend' as longs (user ids), not as user objects

### DIFF
--- a/twitter4j-examples/src/main/java/twitter4j/examples/stream/PrintSiteStreams.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/stream/PrintSiteStreams.java
@@ -176,15 +176,15 @@ public final class PrintSiteStreams {
         }
 
         @Override
-        public void onUserDeletion(long forUser, User deletedUser) {
+        public void onUserDeletion(long forUser, long deletedUser) {
             System.out.println("onUserDeletion for_user:" + forUser
-                    + " user:@" + deletedUser.getScreenName());
+                    + " user:@");
         }
 
         @Override
-        public void onUserSuspension(long forUser, User suspendedUser) {
+        public void onUserSuspension(long forUser, long suspendedUser) {
             System.out.println("onUserSuspension for_user:" + forUser
-                    + " user:@" + suspendedUser.getScreenName());
+                    + " user:@" + suspendedUser);
         }
 
         @Override

--- a/twitter4j-examples/src/main/java/twitter4j/examples/stream/PrintUserStream.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/stream/PrintUserStream.java
@@ -172,13 +172,13 @@ public final class PrintUserStream {
         }
 
         @Override
-        public void onUserDeletion(User deletedUser) {
-            System.out.println("onUserDeletion user:@" + deletedUser.getScreenName());
+        public void onUserDeletion(long deletedUser) {
+            System.out.println("onUserDeletion user:@" + deletedUser);
         }
 
         @Override
-        public void onUserSuspension(User suspendedUser) {
-            System.out.println("onUserSuspension user:@" + suspendedUser.getScreenName());
+        public void onUserSuspension(long suspendedUser) {
+            System.out.println("onUserSuspension user:@" + suspendedUser);
         }
 
         @Override

--- a/twitter4j-stream/src/main/java/twitter4j/SiteStreamsAdapter.java
+++ b/twitter4j-stream/src/main/java/twitter4j/SiteStreamsAdapter.java
@@ -75,11 +75,11 @@ public class SiteStreamsAdapter implements SiteStreamsListener {
     }
 
     @Override
-    public void onUserSuspension(long forUser, User suspendedUser) {
+    public void onUserSuspension(long forUser, long suspendedUser) {
     }
 
     @Override
-    public void onUserDeletion(long forUser, User deletedUser) {
+    public void onUserDeletion(long forUser, long deletedUser) {
     }
 
     @Override

--- a/twitter4j-stream/src/main/java/twitter4j/SiteStreamsImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/SiteStreamsImpl.java
@@ -225,16 +225,16 @@ final class SiteStreamsImpl extends StatusStreamBase {
     }
 
     @Override
-    protected void onUserSuspension(final JSONObject source, final JSONObject target, StreamListener[] listeners) throws TwitterException {
+    protected void onUserSuspension(final long target, StreamListener[] listeners) throws TwitterException {
         for (StreamListener listener : listeners) {
-            ((SiteStreamsListener) listener).onUserSuspension(forUser.get(), asUser(source));
+            ((SiteStreamsListener) listener).onUserSuspension(forUser.get(), target);
         }
     }
 
     @Override
-    protected void onUserDeletion(final JSONObject source, final JSONObject target, StreamListener[] listeners) throws TwitterException {
+    protected void onUserDeletion(final long target, StreamListener[] listeners) throws TwitterException {
         for (StreamListener listener : listeners) {
-            ((SiteStreamsListener) listener).onUserDeletion(forUser.get(), asUser(source));
+            ((SiteStreamsListener) listener).onUserDeletion(forUser.get(), target);
         }
     }
 

--- a/twitter4j-stream/src/main/java/twitter4j/SiteStreamsListener.java
+++ b/twitter4j-stream/src/main/java/twitter4j/SiteStreamsListener.java
@@ -132,17 +132,17 @@ public interface SiteStreamsListener extends StreamListener {
 
     /**
      * @param forUser     the user id to whom sent the event
-     * @param suspendedUser suspended user
+     * @param suspendedUser suspended user id
      * @since Twitter4J 4.0.3
      */
-    void onUserSuspension(long forUser, User suspendedUser);
+    void onUserSuspension(long forUser, long suspendedUser);
 
     /**
      * @param forUser     the user id to whom sent the event
-     * @param deletedUser deleted user
+     * @param deletedUser deleted user id
      * @since Twitter4J 4.0.3
      */
-    void onUserDeletion(long forUser, User deletedUser);
+    void onUserDeletion(long forUser, long deletedUser);
 
     /**
      * @param forUser     the user id to whom sent the event

--- a/twitter4j-stream/src/main/java/twitter4j/StatusStreamBase.java
+++ b/twitter4j-stream/src/main/java/twitter4j/StatusStreamBase.java
@@ -158,10 +158,10 @@ abstract class StatusStreamBase implements StatusStream {
                                         onUserUpdate(json.getJSONObject("source"), json.getJSONObject("target"), listeners);
                                         break;
                                     case USER_DELETE:
-                                        onUserDeletion(json.getJSONObject("source"), json.getJSONObject("target"), listeners);
+                                        onUserDeletion(json.getLong("target"), listeners);
                                         break;
                                     case USER_SUSPEND:
-                                        onUserSuspension(json.getJSONObject("source"), json.getJSONObject("target"), listeners);
+                                        onUserSuspension(json.getLong("target"), listeners);
                                         break;
                                     case BLOCK:
                                         onBlock(json.getJSONObject("source"), json.getJSONObject("target"), listeners);
@@ -282,11 +282,11 @@ abstract class StatusStreamBase implements StatusStream {
         logger.warn("Unhandled event: onUserUpdate");
     }
 
-    void onUserDeletion(JSONObject source, JSONObject target, StreamListener[] listeners) throws TwitterException {
+    void onUserDeletion(long target, StreamListener[] listeners) throws TwitterException {
         logger.warn("Unhandled event: onUserDeletion");
     }
 
-    void onUserSuspension(JSONObject source, JSONObject target, StreamListener[] listeners) throws TwitterException {
+    void onUserSuspension(long target, StreamListener[] listeners) throws TwitterException {
         logger.warn("Unhandled event: onUserSuspension");
     }
 

--- a/twitter4j-stream/src/main/java/twitter4j/UserStreamAdapter.java
+++ b/twitter4j-stream/src/main/java/twitter4j/UserStreamAdapter.java
@@ -82,11 +82,11 @@ public class UserStreamAdapter extends StatusAdapter implements UserStreamListen
     }
 
     @Override
-    public void onUserSuspension(User suspendedUser) {
+    public void onUserSuspension(long suspendedUser) {
     }
 
     @Override
-    public void onUserDeletion(User deletedUser) {
+    public void onUserDeletion(long deletedUser) {
     }
 
     @Override

--- a/twitter4j-stream/src/main/java/twitter4j/UserStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/UserStreamImpl.java
@@ -154,16 +154,16 @@ final class UserStreamImpl extends StatusStreamImpl implements UserStream {
     }
 
     @Override
-    protected void onUserSuspension(JSONObject source, JSONObject target, StreamListener[] listeners) throws TwitterException {
+    protected void onUserSuspension(long target, StreamListener[] listeners) throws TwitterException {
         for (StreamListener listener : listeners) {
-            ((UserStreamListener) listener).onUserSuspension(asUser(source));
+            ((UserStreamListener) listener).onUserSuspension(target);
         }
     }
 
     @Override
-    protected void onUserDeletion(JSONObject source, JSONObject target, StreamListener[] listeners) throws TwitterException {
+    protected void onUserDeletion(long target, StreamListener[] listeners) throws TwitterException {
         for (StreamListener listener : listeners) {
-            ((UserStreamListener) listener).onUserDeletion(asUser(source));
+            ((UserStreamListener) listener).onUserDeletion(target);
         }
     }
 

--- a/twitter4j-stream/src/main/java/twitter4j/UserStreamListener.java
+++ b/twitter4j-stream/src/main/java/twitter4j/UserStreamListener.java
@@ -125,16 +125,16 @@ public interface UserStreamListener extends StatusListener {
     void onUserProfileUpdate(User updatedUser);
 
     /**
-     * @param suspendedUser suspended user
+     * @param suspendedUser suspended user id
      * @since Twitter4J 4.0.3
      */
-    void onUserSuspension(User suspendedUser);
+    void onUserSuspension(long suspendedUser);
 
     /**
-     * @param deletedUser deleted user
+     * @param deletedUser deleted user id
      * @since Twitter4J 4.0.3
      */
-    void onUserDeletion(User deletedUser);
+    void onUserDeletion(long deletedUser);
 
     /**
      * @param source      source user of the event

--- a/twitter4j-stream/src/test/java/twitter4j/SiteStreamsTest.java
+++ b/twitter4j-stream/src/test/java/twitter4j/SiteStreamsTest.java
@@ -378,14 +378,14 @@ public class SiteStreamsTest extends TwitterTestBase implements SiteStreamsListe
     }
 
     @Override
-    public void onUserDeletion(long forUser, User deletedUser) {
+    public void onUserDeletion(long forUser, long deletedUser) {
         received.add(new Object[]{"user_delete", forUser, deletedUser});
         Assert.assertNotNull(TwitterObjectFactory.getRawJSON(deletedUser));
         notifyResponse();
     }
 
     @Override
-    public void onUserSuspension(long forUser, User suspendedUser) {
+    public void onUserSuspension(long forUser, long suspendedUser) {
         received.add(new Object[]{"user_suspend", forUser, suspendedUser});
         Assert.assertNotNull(TwitterObjectFactory.getRawJSON(suspendedUser));
         notifyResponse();

--- a/twitter4j-stream/src/test/java/twitter4j/UserStreamTest.java
+++ b/twitter4j-stream/src/test/java/twitter4j/UserStreamTest.java
@@ -394,18 +394,16 @@ public class UserStreamTest extends TwitterTestBase implements UserStreamListene
     }
 
     @Override
-    public void onUserDeletion(User deletedUser) {
+    public void onUserDeletion(long deletedUser) {
         System.out.println("onUserDeletion");
         received.add(new Object[]{"user_delete", deletedUser});
-        Assert.assertNotNull(TwitterObjectFactory.getRawJSON(deletedUser));
         notifyResponse();
     }
 
     @Override
-    public void onUserSuspension(User suspendedUser) {
+    public void onUserSuspension(long suspendedUser) {
         System.out.println("onUserSuspension");
         received.add(new Object[]{"user_suspend", suspendedUser});
-        Assert.assertNotNull(TwitterObjectFactory.getRawJSON(suspendedUser));
         notifyResponse();
     }
 


### PR DESCRIPTION
The target fields of 'user_delete' and 'user_suspend' are longs, not user objects.
My patch (#171) was broken and this pull request should fix it.
