### PR TITLE
Added closed = true to avoid infinite loop where closed is always false

### DIFF
--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -504,6 +504,7 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
                                 stream.next(this.streamListeners, this.rawStreamListeners);
                             } catch (IllegalStateException ise) {
                                 logger.warn(ise.getMessage());
+                                closed = true;
                                 break;
                             } catch (TwitterException e) {
                                 logger.info(e.getMessage());


### PR DESCRIPTION
We ran into an issue where this line would be logged as a warning "Stream already closed." and our application would fail to reconnect to sitestream.

I worked backwards from twitter4j.StatusStreamBase.handleNextElement(StreamListener[], RawStreamListener[]) where it throws an IllegalStateException and noticed that the exception was being caught and logged in TwitterStreamImpl, but "closed" and "stream" were not modified. This creates an infinite loop in the outer while loop of the run() method.

Setting closed = true prevents the infinite loop, but there might be a better solution.
