### PR TITLE
TFJ-893 TwitterObjectFactory methods must not register rawJSON

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,7 @@ Eli Israel <eli at meshfire.com> @eliasisrael
 Enrico Candino <enrico.candino at gmail.com> @enrichmann
 Eric Jensen <ej at twitter.com> @ej
 Fiaz Hossain <fiaz at twitter.com> @fiazhossain
+Flavio Martins <flaviomartins at acm.org> @flaviomartins
 Fran Garcia <fgarciarico at gmail.com> @frangarcia
 Gabriel Zanetti @pupi1985
 George Ludwig <georgeludwig at gmail.com> @georgeludwig

--- a/twitter4j-core/src/main/java/twitter4j/TwitterObjectFactory.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterObjectFactory.java
@@ -299,13 +299,13 @@ public final class TwitterObjectFactory {
             JSONObjectType.Type jsonObjectType = JSONObjectType.determine(json);
             switch (jsonObjectType) {
                 case SENDER:
-                    return registerJSONObject(new DirectMessageJSONImpl(json.getJSONObject("direct_message")), json);
+                    return new DirectMessageJSONImpl(json.getJSONObject("direct_message"));
                 case STATUS:
-                    return registerJSONObject(new StatusJSONImpl(json), json);
+                    return new StatusJSONImpl(json);
                 case DIRECT_MESSAGE:
-                    return registerJSONObject(new DirectMessageJSONImpl(json.getJSONObject("direct_message")), json);
+                    return new DirectMessageJSONImpl(json.getJSONObject("direct_message"));
                 case DELETE:
-                    return registerJSONObject(new StatusDeletionNoticeImpl(json.getJSONObject("delete").getJSONObject("status")), json);
+                    return new StatusDeletionNoticeImpl(json.getJSONObject("delete").getJSONObject("status"));
                 case LIMIT:
                     // TODO: Perhaps there should be a TrackLimitationNotice object?
                     // The onTrackLimitationNotice method could take that as an arg.


### PR DESCRIPTION
Recently we were parsing huge files in json lines format (one Status per line) and found OutOfMemory errors. I traced it back to calls to the static method createObject() in TwitterObjectFactory.

Currently the rawJSON is saved to a Map and never cleared even if jsonStoreEnabled setting is set to false. My fix is removing the calls to registerJSONObject() in createObject(), since it seems highly unlikely that the caller to createObject() does not have better ways to access the rawJSON.
