### PR TITLE
Added Support for UnshortenedUrl in URLEntity

### DIFF
--- a/twitter4j-core/src/internal-json/java/twitter4j/MediaEntityJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/MediaEntityJSONImpl.java
@@ -30,6 +30,7 @@ public class MediaEntityJSONImpl extends EntityIndex implements MediaEntity {
     private String mediaURLHttps;
     private String expandedURL;
     private String displayURL;
+    private String unshortenedURL;
     private Map<Integer, MediaEntity.Size> sizes;
     protected String type;
     private int videoAspectRatioWidth;
@@ -61,6 +62,14 @@ public class MediaEntityJSONImpl extends EntityIndex implements MediaEntity {
             addMediaEntitySizeIfNotNull(this.sizes, sizes, MediaEntity.Size.THUMB, "thumb");
             if (!json.isNull("type")) {
                 this.type = json.getString("type");
+            }
+
+            if (!json.isNull("unshortened_url")) {
+                // sets displayURL to url if expanded_url is null
+                // http://jira.twitter4j.org/browse/TFJ-704
+                this.unshortenedURL = json.getString("unshortened_url");
+            } else {
+                this.unshortenedURL = expandedURL;
             }
 
             if (json.has("video_info")) {
@@ -136,6 +145,11 @@ public class MediaEntityJSONImpl extends EntityIndex implements MediaEntity {
     @Override
     public String getExpandedURL() {
         return expandedURL;
+    }
+
+    @Override
+    public String getUnshortenedURL() {
+        return unshortenedURL;
     }
 
     @Override

--- a/twitter4j-core/src/internal-json/java/twitter4j/URLEntityJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/URLEntityJSONImpl.java
@@ -24,10 +24,11 @@ package twitter4j;
  */
 /* package */ final class URLEntityJSONImpl extends EntityIndex implements URLEntity {
 
-    private static final long serialVersionUID = 7333552738058031524L;
+    private static final long serialVersionUID = 7333552738058031525L;
     private String url;
     private String expandedURL;
     private String displayURL;
+    private String unshortenedURL;
 
     /* package */ URLEntityJSONImpl(JSONObject json) throws TwitterException {
         super();
@@ -41,6 +42,16 @@ package twitter4j;
         this.url = url;
         this.expandedURL = expandedURL;
         this.displayURL = displayURL;
+    }
+
+    /* package */ URLEntityJSONImpl(int start, int end, String url, String expandedURL, String displayURL, String unshortenedURL) {
+        super();
+        setStart(start);
+        setEnd(end);
+        this.url = url;
+        this.expandedURL = expandedURL;
+        this.displayURL = displayURL;
+        this.unshortenedURL = unshortenedURL;
     }
 
     /* For serialization purposes only. */
@@ -73,6 +84,14 @@ package twitter4j;
             } else {
                 this.displayURL = url;
             }
+
+            if (!json.isNull("unshortened_url")) {
+                // sets displayURL to url if expanded_url is null
+                // http://jira.twitter4j.org/browse/TFJ-704
+                this.unshortenedURL = json.getString("unshortened_url");
+            } else {
+                this.unshortenedURL = this.expandedURL;
+            }
         } catch (JSONException jsone) {
             throw new TwitterException(jsone);
         }
@@ -96,6 +115,11 @@ package twitter4j;
     @Override
     public String getDisplayURL() {
         return displayURL;
+    }
+
+    @Override
+    public String getUnshortenedURL() {
+        return unshortenedURL;
     }
 
     @Override
@@ -136,6 +160,7 @@ package twitter4j;
                 "url='" + url + '\'' +
                 ", expandedURL='" + expandedURL + '\'' +
                 ", displayURL='" + displayURL + '\'' +
+                ", unshortenedURL='" + unshortenedURL + '\'' +
                 '}';
     }
 }

--- a/twitter4j-core/src/main/java/twitter4j/URLEntity.java
+++ b/twitter4j-core/src/main/java/twitter4j/URLEntity.java
@@ -48,6 +48,13 @@ public interface URLEntity extends TweetEntity, java.io.Serializable {
     String getExpandedURL();
 
     /**
+     * Returns the unshortened URL if mentioned URL is shorten.
+     *
+     * @return the unshortened URL if mentioned URL is shorten, or null if no shorten URL was mentioned.
+     */
+    String getUnshortenedURL();
+
+    /**
      * Returns the display URL if mentioned URL is shorten.
      *
      * @return the display URL if mentioned URL is shorten, or null if no shorten URL was mentioned.


### PR DESCRIPTION
In some instances, Twitter automatically expands URLs that were
shortened using a URL shortener. These expanded URLs get embedded in the
JSON as an unshortened_url field in the .entities.urls list.

If no unshortened_url is given, we populate it with the existing expanded_url
field.