### PR TITLE
update travis build for multiple JDK versions (8,9,10,11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: java
+
 jdk:
   - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10
+  - oraclejdk-ea
+  - openjdk10
+  - openjdk11
+
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
Travis support multiple JDK's up to 11. This PR is simply to update the trivus build to use the various supported JDK versions.