### PR TITLE
Removed error introducted by auto-merge

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/DirectMessage.java
+++ b/twitter4j-core/src/main/java/twitter4j/DirectMessage.java
@@ -54,19 +54,5 @@ public interface DirectMessage extends TwitterResponse, EntitySupport, java.io.S
      */
     String getQuickReplyResponse();
 
-    /**
-     *
-     * @return quick reply options
-     * @since Twitter4J 4.0.7
-     */
-    QuickReply[] getQuickReplies();
-
-    /**
-     *
-     * @return quick reply response metadata
-     * @since Twitter4J 4.0.7
-     */
-    String getQuickReplyResponse();
-
     // currently type is always "message_create". So we're not providing a getter for that.
 }


### PR DESCRIPTION
Merging the `quick-reply` branch created a double declaration of functions inside the `DirectMessage` class. Removing these allows `twitter4j-core` to be compiled again.