### PR TITLE
Add a callback method for OkHttp3 to support TLS 1.2 on Android 4.x devices

### DIFF
--- a/twitter4j-http2-support/src/main/java/twitter4j/AlternativeHttpClientImpl.java
+++ b/twitter4j-http2-support/src/main/java/twitter4j/AlternativeHttpClientImpl.java
@@ -50,7 +50,13 @@ public class AlternativeHttpClientImpl extends HttpClientBase implements HttpRes
     private static final MediaType FORM_URL_ENCODED = MediaType.parse("application/x-www-form-urlencoded");
     private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
 
+    public interface OnBuildOkHttpClientCallback {
+        void onBuildOkHttpClient(OkHttpClient.Builder builder);
+    }
+
     private OkHttpClient okHttpClient;
+
+    private static OnBuildOkHttpClientCallback onBuildOkHttpClient = null;
 
     //for test
     public static boolean sPreferHttp2 = true;
@@ -63,7 +69,6 @@ public class AlternativeHttpClientImpl extends HttpClientBase implements HttpRes
     public AlternativeHttpClientImpl(HttpClientConfiguration conf) {
         super(conf);
     }
-
 
     @Override
     HttpResponse handleRequest(HttpRequest req) throws TwitterException {
@@ -290,8 +295,17 @@ public class AlternativeHttpClientImpl extends HttpClientBase implements HttpRes
                 builder.readTimeout(CONF.getHttpReadTimeout(), TimeUnit.MILLISECONDS);
             }
 
+            // fix TLS1.2 etc...
+            if (onBuildOkHttpClient != null) {
+                onBuildOkHttpClient.onBuildOkHttpClient(builder);
+            }
+
             okHttpClient = builder.build();
         }
+    }
+
+    public static void setOnBuildOkHttpClient(OnBuildOkHttpClientCallback callback) {
+        onBuildOkHttpClient = callback;
     }
 
     //for test


### PR DESCRIPTION
Twitter API requires TLS 1.2 since July 30, 2019, 

Android 4.x devices do not support TLS 1.2 by default. 
Therefore, this PR provides a callback method to support TLS 1.2 on Android 4.x devices.

- [Removing support for legacy TLS versions \(1\.0/1\.1\) on Twitter \- Announcements \- Twitter Developers](https://twittercommunity.com/t/removing-support-for-legacy-tls-versions-1-0-1-1-on-twitter/126648)
- [Android 4\.1\+ enable TLS 1\.1 and TLS 1\.2 \- blog\.dev\-area\.net](https://blog.dev-area.net/2015/08/13/android-4-1-enable-tls-1-1-and-tls-1-2/)
- [Android4系端末のTLS1\.1&1\.2対応について \- Qiita](https://qiita.com/ntsk/items/9f31fc7b44c04ea45e0b)