### PR TITLE
Remove duplicate method signatures in DirectMessage interface

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/DirectMessage.java
+++ b/twitter4j-core/src/main/java/twitter4j/DirectMessage.java
@@ -54,19 +54,5 @@ public interface DirectMessage extends TwitterResponse, EntitySupport, java.io.S
      */
     String getQuickReplyResponse();
 
-    /**
-     *
-     * @return quick reply options
-     * @since Twitter4J 4.0.7
-     */
-    QuickReply[] getQuickReplies();
-
-    /**
-     *
-     * @return quick reply response metadata
-     * @since Twitter4J 4.0.7
-     */
-    String getQuickReplyResponse();
-
     // currently type is always "message_create". So we're not providing a getter for that.
 }


### PR DESCRIPTION
This caused an error with the maven compile command.