### PR TITLE
[OAuth] Add OAuth access token invalidation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Robson Cassol <robsoncassol at gmail.com> @robsoncassol
 Roy Reshef <royreshef at gmail.com> @tsipo
 Rui Silva
 Sam Pullara <sam at sampullara.com> @sampullara
+Sami Shahin <ssshahin at bu.edu> @dr_wisper
 Sdk0815 <developer at terumode.net> @Sdk0815
 Shane Gibson <shane.a.gibson at gmail.com> @shaneagibson
 Shintaro Watanabe <shintaro.watanabe1226@gmail.com> @shin_taro_1226

--- a/twitter4j-async/src/main/java/twitter4j/AsyncTwitterImpl.java
+++ b/twitter4j-async/src/main/java/twitter4j/AsyncTwitterImpl.java
@@ -2835,6 +2835,11 @@ class AsyncTwitterImpl extends TwitterBaseImpl implements AsyncTwitter {
     }
 
     @Override
+    public synchronized void invalidateOAuthToken() throws TwitterException {
+        twitter.invalidateOAuthToken();
+    }
+
+    @Override
     public synchronized void invalidateOAuth2Token() throws TwitterException {
         twitter.invalidateOAuth2Token();
     }

--- a/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
@@ -396,6 +396,11 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
     }
 
     @Override
+    public synchronized void invalidateOAuthToken() throws TwitterException {
+        getOAuth().invalidateOAuthToken();
+    }
+
+    @Override
     public synchronized void invalidateOAuth2Token() throws TwitterException {
         getOAuth2().invalidateOAuth2Token();
     }

--- a/twitter4j-core/src/main/java/twitter4j/auth/OAuthAuthorization.java
+++ b/twitter4j-core/src/main/java/twitter4j/auth/OAuthAuthorization.java
@@ -181,6 +181,39 @@ public class OAuthAuthorization implements Authorization, java.io.Serializable, 
         this.realm = realm;
     }
 
+    /**
+     * Invalidates the OAuth token
+     *
+     * On success, sets oauthToken to null
+     * @throws TwitterException when Twitter service or network is unavailable, or the user has not authorized
+     */
+    @Override
+    public void invalidateOAuthToken() throws TwitterException {
+        if (oauthToken == null) {
+            throw new IllegalStateException("OAuth Token is not available.");
+        }
+
+        HttpParameter[] params = new HttpParameter[1];
+        params[0] = new HttpParameter("access_token", getOAuthAccessToken().getToken());
+
+        OAuthToken _token = oauthToken;
+        boolean succeed = false;
+
+        try {
+            HttpResponse res = http.post(conf.getOAuthInvalidateTokenURL(), params, this, null);
+            if (res.getStatusCode() != 200) {
+                throw new TwitterException("Invalidating OAuth Token failed.", res);
+            }
+
+            succeed = true;
+
+        } finally {
+            oauthToken = null;
+            if (!succeed) {
+                oauthToken = _token;
+            }
+        }
+    }
 
     /*package*/ String generateAuthorizationHeader(String method, String url, HttpParameter[] params, String nonce, String timestamp, OAuthToken otoken) {
         if (null == params) {

--- a/twitter4j-core/src/main/java/twitter4j/auth/OAuthSupport.java
+++ b/twitter4j-core/src/main/java/twitter4j/auth/OAuthSupport.java
@@ -166,4 +166,11 @@ public interface OAuthSupport {
      * @since Twitter4J 2.0.0
      */
     void setOAuthAccessToken(AccessToken accessToken);
+
+    /**
+     * Invalidates the OAuth token
+     *
+     * @throws TwitterException when Twitter service or network is unavailable, or the user has not authorized
+     */
+    void invalidateOAuthToken() throws TwitterException;
 }

--- a/twitter4j-core/src/main/java/twitter4j/conf/Configuration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/Configuration.java
@@ -79,6 +79,8 @@ public interface Configuration extends AuthorizationConfiguration, java.io.Seria
 
     String getOAuth2TokenURL();
 
+    String getOAuthInvalidateTokenURL();
+
     String getOAuth2InvalidateTokenURL();
 
     String getUserStreamBaseURL();

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
@@ -54,6 +54,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
     private String oAuthAuthorizationURL = "https://api.twitter.com/oauth/authorize";
     private String oAuthAccessTokenURL = "https://api.twitter.com/oauth/access_token";
     private String oAuthAuthenticationURL = "https://api.twitter.com/oauth/authenticate";
+    private String oAuthInvalidateTokenURL = "https://api.twitter.com/1.1/oauth/invalidate_token";
     private String oAuth2TokenURL = "https://api.twitter.com/oauth2/token";
     private String oAuth2InvalidateTokenURL = "https://api.twitter.com/oauth2/invalidate_token";
 
@@ -589,6 +590,15 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
 
     protected final void setOAuth2TokenURL(String oAuth2TokenURL) {
         this.oAuth2TokenURL = oAuth2TokenURL;
+    }
+
+    @Override
+    public String getOAuthInvalidateTokenURL() {
+        return oAuthInvalidateTokenURL;
+    }
+
+    protected final void setOAuthInvalidateTokenURL(String oAuthInvalidateTokenURL) {
+        this.oAuthInvalidateTokenURL = oAuthInvalidateTokenURL;
     }
 
     @Override


### PR DESCRIPTION
- Add invalidate token endpoint to ConfigurationBase
- Add invalidateOAuthToken() to OAuthAuthorization

This change allows OAuth 1.0 access tokens to be invalidated.
See https://developer.twitter.com/en/docs/basics/authentication/api-reference/invalidate_access_token
for more information

This is my first contribution to Twitter4J. If there are any contributing guidelines to follow, I'd be happy to adjust my PR to meet them. :)