### PR TITLE
Add additional_media_info for video

### DIFF
--- a/twitter4j-core/src/internal-json/java/twitter4j/MediaEntityJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/MediaEntityJSONImpl.java
@@ -84,7 +84,7 @@ public class MediaEntityJSONImpl extends EntityIndex implements MediaEntity {
             }
 
             if (json.has("ext_alt_text")) {
-                extAltText = json.getString("ext_alt_text");
+                this.extAltText = json.getString("ext_alt_text");
             }
 
         } catch (JSONException jsone) {

--- a/twitter4j-core/src/internal-json/java/twitter4j/MediaEntityJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/MediaEntityJSONImpl.java
@@ -37,6 +37,11 @@ public class MediaEntityJSONImpl extends EntityIndex implements MediaEntity {
     private long videoDurationMillis;
     private Variant[] videoVariants;
     private String extAltText;
+    private String additionalMediaTitle;
+    private String additionalMediaDescription;
+    private Boolean additionalMediaEmbeddable;
+    private Boolean additionalMediaMonetizable;
+    private User additionalMediaSourceUser;
 
 
     MediaEntityJSONImpl(JSONObject json) throws TwitterException {
@@ -85,6 +90,17 @@ public class MediaEntityJSONImpl extends EntityIndex implements MediaEntity {
 
             if (json.has("ext_alt_text")) {
                 this.extAltText = json.getString("ext_alt_text");
+            }
+
+            if (json.has("additional_media_info")) {
+                JSONObject additionalMediaInfo = json.getJSONObject("additional_media_info");
+                this.additionalMediaTitle = additionalMediaInfo.optString("title", null);
+                this.additionalMediaDescription = additionalMediaInfo.optString("description", null);
+                this.additionalMediaEmbeddable = additionalMediaInfo.optBoolean("embeddable", false);
+                this.additionalMediaMonetizable = additionalMediaInfo.optBoolean("monetizable", false);
+                if (!additionalMediaInfo.isNull("source_user")) {
+                    this.additionalMediaSourceUser = new UserJSONImpl(additionalMediaInfo.getJSONObject("source_user"));
+                }
             }
 
         } catch (JSONException jsone) {
@@ -240,6 +256,31 @@ public class MediaEntityJSONImpl extends EntityIndex implements MediaEntity {
     @Override
     public String getExtAltText() {
         return extAltText;
+    }
+
+    @Override
+    public String getAdditionalMediaTitle() {
+        return additionalMediaTitle;
+    }
+
+    @Override
+    public String getAdditionalMediaDescription() {
+        return additionalMediaDescription;
+    }
+
+    @Override
+    public Boolean getAdditionalMediaEmbeddable() {
+        return additionalMediaEmbeddable;
+    }
+
+    @Override
+    public Boolean getAdditionalMediaMonetizable() {
+        return additionalMediaMonetizable;
+    }
+
+    @Override
+    public User getAdditionalMediaSourceUser() {
+        return additionalMediaSourceUser;
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/MediaEntity.java
+++ b/twitter4j-core/src/main/java/twitter4j/MediaEntity.java
@@ -90,4 +90,15 @@ public interface MediaEntity extends URLEntity {
     Variant[] getVideoVariants();
 
     String getExtAltText();
+
+    String getAdditionalMediaTitle();
+
+    String getAdditionalMediaDescription();
+
+    Boolean getAdditionalMediaEmbeddable();
+
+    Boolean getAdditionalMediaMonetizable();
+
+    User getAdditionalMediaSourceUser();
+
 }

--- a/twitter4j-core/src/test/java/twitter4j/MediaEntityJSONImplTest.java
+++ b/twitter4j-core/src/test/java/twitter4j/MediaEntityJSONImplTest.java
@@ -98,7 +98,53 @@ class MediaEntityJSONImplTest {
                 mediaEntity.getMediaURL());
 
         assertEquals("カレーパンマンのパズル的なやつ", mediaEntity.getExtAltText());
+
+        assertNull(mediaEntity.getAdditionalMediaTitle());
+        assertNull(mediaEntity.getAdditionalMediaDescription());
+        assertNull(mediaEntity.getAdditionalMediaEmbeddable());
+        assertNull(mediaEntity.getAdditionalMediaMonetizable());
+        assertNull(mediaEntity.getAdditionalMediaSourceUser());
     }
 
+
+    @Test
+    void testAdditionalMediaInfo_NoTitleDescription() throws Exception {
+
+        //given from https://api.twitter.com/1.1/statuses/show/1240874970198097920.json?include_ext_alt_text=true
+        String rawJson = "{\"extended_entities\":{\"media\":[{\"id\":1236671586075316200,\"id_str\":\"1236671586075316225\",\"indices\":[5,28],\"media_url\":\"http://pbs.twimg.com/ext_tw_video_thumb/1236671586075316225/pu/img/xRVEs8EhJqVfFW3C.jpg\",\"media_url_https\":\"https://pbs.twimg.com/ext_tw_video_thumb/1236671586075316225/pu/img/xRVEs8EhJqVfFW3C.jpg\",\"url\":\"https://t.co/3n6G7n7PJS\",\"display_url\":\"pic.twitter.com/3n6G7n7PJS\",\"expanded_url\":\"https://twitter.com/Velovebikes/status/1236671921565114369/video/1\",\"type\":\"video\",\"sizes\":{\"thumb\":{\"w\":150,\"h\":150,\"resize\":\"crop\"},\"medium\":{\"w\":1200,\"h\":675,\"resize\":\"fit\"},\"small\":{\"w\":680,\"h\":383,\"resize\":\"fit\"},\"large\":{\"w\":1280,\"h\":720,\"resize\":\"fit\"}},\"source_status_id\":1236671921565114400,\"source_status_id_str\":\"1236671921565114369\",\"source_user_id\":3155196136,\"source_user_id_str\":\"3155196136\",\"video_info\":{\"aspect_ratio\":[16,9],\"duration_millis\":48882,\"variants\":[{\"content_type\":\"application/x-mpegURL\",\"url\":\"https://video.twimg.com/ext_tw_video/1236671586075316225/pu/pl/H66SGUD8VuLr06Ts.m3u8?tag=10\"},{\"bitrate\":832000,\"content_type\":\"video/mp4\",\"url\":\"https://video.twimg.com/ext_tw_video/1236671586075316225/pu/vid/640x360/Uj_6_08M8TVgtmLG.mp4?tag=10\"},{\"bitrate\":256000,\"content_type\":\"video/mp4\",\"url\":\"https://video.twimg.com/ext_tw_video/1236671586075316225/pu/vid/480x270/897atp68fJA_UyLo.mp4?tag=10\"},{\"bitrate\":2176000,\"content_type\":\"video/mp4\",\"url\":\"https://video.twimg.com/ext_tw_video/1236671586075316225/pu/vid/1280x720/WYTvCJm0C3QmLOhY.mp4?tag=10\"}]},\"ext_alt_text\":null,\"additional_media_info\":{\"monetizable\":false,\"source_user\":{\"id\":3155196136,\"id_str\":\"3155196136\",\"name\":\"Velove\",\"screen_name\":\"Velovebikes\",\"location\":\"Goteborg, Sverige\",\"description\":\"Velove solutions are improving productivity in last mile delivery. Try the Armadillo electric cargo bike and get a smile on your face!\",\"url\":\"http://t.co/D0OLfakwLf\",\"entities\":{\"url\":{\"urls\":[{\"url\":\"http://t.co/D0OLfakwLf\",\"expanded_url\":\"http://www.velove.se\",\"display_url\":\"velove.se\",\"indices\":[0,22]}]},\"description\":{\"urls\":[]}},\"protected\":false,\"followers_count\":2038,\"friends_count\":422,\"listed_count\":52,\"created_at\":\"Sat Apr 11 04:25:03 +0000 2015\",\"favourites_count\":578,\"utc_offset\":null,\"time_zone\":null,\"geo_enabled\":true,\"verified\":false,\"statuses_count\":1301,\"lang\":null,\"contributors_enabled\":false,\"is_translator\":false,\"is_translation_enabled\":false,\"profile_background_color\":\"000000\",\"profile_background_image_url\":\"http://abs.twimg.com/images/themes/theme1/bg.png\",\"profile_background_image_url_https\":\"https://abs.twimg.com/images/themes/theme1/bg.png\",\"profile_background_tile\":false,\"profile_image_url\":\"http://pbs.twimg.com/profile_images/1097046595944808448/cb7FlNbw_normal.png\",\"profile_image_url_https\":\"https://pbs.twimg.com/profile_images/1097046595944808448/cb7FlNbw_normal.png\",\"profile_banner_url\":\"https://pbs.twimg.com/profile_banners/3155196136/1543163176\",\"profile_image_extensions_alt_text\":null,\"profile_banner_extensions_alt_text\":null,\"profile_link_color\":\"1F2A44\",\"profile_sidebar_border_color\":\"000000\",\"profile_sidebar_fill_color\":\"000000\",\"profile_text_color\":\"000000\",\"profile_use_background_image\":false,\"has_extended_profile\":false,\"default_profile\":false,\"default_profile_image\":false,\"following\":false,\"follow_request_sent\":false,\"notifications\":false,\"translator_type\":\"none\"}}}]}}";
+
+        //when
+        JSONObject json = new JSONObject(rawJson);
+        MediaEntityJSONImpl mediaEntity = new MediaEntityJSONImpl(json.getJSONObject("extended_entities").getJSONArray("media").getJSONObject(0));
+
+        //then
+        assertEquals(1236671586075316200L, mediaEntity.getId());
+        assertNull(mediaEntity.getAdditionalMediaTitle());
+        assertNull(mediaEntity.getAdditionalMediaDescription());
+        assertEquals(false, mediaEntity.getAdditionalMediaEmbeddable());
+        assertEquals(false, mediaEntity.getAdditionalMediaMonetizable());
+        assertEquals(3155196136L, mediaEntity.getAdditionalMediaSourceUser().getId());
+        assertEquals("Velovebikes", mediaEntity.getAdditionalMediaSourceUser().getScreenName());
+    }
+
+    @Test
+    void testAdditionalMediaInfo_HasTitleDescription() throws Exception {
+
+        //given from https://api.twitter.com/1.1/statuses/show/1242632305895587840.json?include_ext_alt_text=true
+        String rawJson = "{\"extended_entities\":{\"media\":[{\"id\":924685332347469800,\"id_str\":\"924685332347469824\",\"indices\":[8,31],\"media_url\":\"http://pbs.twimg.com/media/DNUkdLMVwAEzj8K.jpg\",\"media_url_https\":\"https://pbs.twimg.com/media/DNUkdLMVwAEzj8K.jpg\",\"url\":\"https://t.co/6F89Oxb5UB\",\"display_url\":\"pic.twitter.com/6F89Oxb5UB\",\"expanded_url\":\"https://twitter.com/nyjets/status/924685391524798464/video/1\",\"type\":\"photo\",\"sizes\":{\"thumb\":{\"w\":150,\"h\":150,\"resize\":\"crop\"},\"medium\":{\"w\":1200,\"h\":675,\"resize\":\"fit\"},\"small\":{\"w\":680,\"h\":383,\"resize\":\"fit\"},\"large\":{\"w\":1280,\"h\":720,\"resize\":\"fit\"}},\"source_status_id\":924685391524798500,\"source_status_id_str\":\"924685391524798464\",\"source_user_id\":17076218,\"source_user_id_str\":\"17076218\",\"ext_alt_text\":null,\"additional_media_info\":{\"title\":\"#ATLvsNYJ: Tomlinson TD from McCown\",\"description\":\"NFL\",\"embeddable\":false,\"monetizable\":true,\"source_user\":{\"id\":17076218,\"id_str\":\"17076218\",\"name\":\"New York Jets\",\"screen_name\":\"nyjets\",\"location\":\"New York\",\"description\":\"#TakeFlight\",\"url\":\"https://t.co/PdZCEFcc1B\",\"entities\":{\"url\":{\"urls\":[{\"url\":\"https://t.co/PdZCEFcc1B\",\"expanded_url\":\"http://nyjets.com\",\"display_url\":\"nyjets.com\",\"indices\":[0,23]}]},\"description\":{\"urls\":[]}},\"protected\":false,\"followers_count\":1249925,\"friends_count\":11585,\"listed_count\":8168,\"created_at\":\"Thu Oct 30 22:40:49 +0000 2008\",\"favourites_count\":3289,\"utc_offset\":null,\"time_zone\":null,\"geo_enabled\":true,\"verified\":true,\"statuses_count\":62178,\"lang\":null,\"contributors_enabled\":false,\"is_translator\":false,\"is_translation_enabled\":false,\"profile_background_color\":\"131516\",\"profile_background_image_url\":\"http://abs.twimg.com/images/themes/theme14/bg.gif\",\"profile_background_image_url_https\":\"https://abs.twimg.com/images/themes/theme14/bg.gif\",\"profile_background_tile\":false,\"profile_image_url\":\"http://pbs.twimg.com/profile_images/1204029633286590464/T584Ys8V_normal.jpg\",\"profile_image_url_https\":\"https://pbs.twimg.com/profile_images/1204029633286590464/T584Ys8V_normal.jpg\",\"profile_banner_url\":\"https://pbs.twimg.com/profile_banners/17076218/1582228846\",\"profile_image_extensions_alt_text\":null,\"profile_banner_extensions_alt_text\":null,\"profile_link_color\":\"009999\",\"profile_sidebar_border_color\":\"FFFFFF\",\"profile_sidebar_fill_color\":\"EFEFEF\",\"profile_text_color\":\"333333\",\"profile_use_background_image\":true,\"has_extended_profile\":false,\"default_profile\":false,\"default_profile_image\":false,\"following\":false,\"follow_request_sent\":false,\"notifications\":false,\"translator_type\":\"none\"}}}]}}";
+
+        //when
+        JSONObject json = new JSONObject(rawJson);
+        MediaEntityJSONImpl mediaEntity = new MediaEntityJSONImpl(json.getJSONObject("extended_entities").getJSONArray("media").getJSONObject(0));
+
+        //then
+        assertEquals(924685332347469800L, mediaEntity.getId());
+        assertEquals("#ATLvsNYJ: Tomlinson TD from McCown", mediaEntity.getAdditionalMediaTitle());
+        assertEquals("NFL", mediaEntity.getAdditionalMediaDescription());
+        assertEquals(false, mediaEntity.getAdditionalMediaEmbeddable());
+        assertEquals(true, mediaEntity.getAdditionalMediaMonetizable());
+        assertEquals(17076218L, mediaEntity.getAdditionalMediaSourceUser().getId());
+        assertEquals("nyjets", mediaEntity.getAdditionalMediaSourceUser().getScreenName());
+    }
 
 }


### PR DESCRIPTION
Some new tweets have `additional_media_info` for embedded videos.

Example: https://twitter.com/takke/status/1242632305895587840

This PR adds these info into `MediaEntitiy`.

- Official Document: [Extended entities object — Twitter Developers](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/extended-entities-object)
  - Note that there is no description about `source_user`
