### PR TITLE
Fix getter/setter synchronized in pairs

### DIFF
--- a/twitter4j-async/src/main/java/twitter4j/AsyncTwitterImpl.java
+++ b/twitter4j-async/src/main/java/twitter4j/AsyncTwitterImpl.java
@@ -2814,7 +2814,7 @@ class AsyncTwitterImpl extends TwitterBaseImpl implements AsyncTwitter {
     }
 
     @Override
-    public void setOAuth2Token(OAuth2Token oauth2Token) {
+    public synchronized void setOAuth2Token(OAuth2Token oauth2Token) {
         twitter.setOAuth2Token(oauth2Token);
     }
 

--- a/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
@@ -391,7 +391,7 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
     }
 
     @Override
-    public void setOAuth2Token(OAuth2Token oauth2Token) {
+    public synchronized void setOAuth2Token(OAuth2Token oauth2Token) {
         getOAuth2().setOAuth2Token(oauth2Token);
     }
 


### PR DESCRIPTION
Due to Sonar `java:S2886`:
> Getters and setters should be synchronized in pairs
>
> When one part of a getter/setter pair is synchronized the other part should be too. Failure to synchronize both sides of a pair may result in inconsistent behavior at runtime as callers access an inconsistent method state.
>
>This rule raises an issue when either the method or the contents of one method in a getter/setter pair are synchronized but the other is not.

For more info see this
[CERT, VNA01-J.](https://wiki.sei.cmu.edu/confluence/x/4jdGBQ) - Ensure visibility of shared references to immutable objects