### PR TITLE
Update Gradle example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add a dependency declaration to pom.xml, or build.gradle as follows:
 ### Gradle
 ```text
 dependencies {
-    compile 'org.twitter4j:twitter4j-core:4.1.2'
+    implementation 'org.twitter4j:twitter4j-core:4.1.2'
 }
 ```
 


### PR DESCRIPTION
"compile" is obsolete, changed to "implementation"
[Gradle の compile, api, implementation とかについて - Qiita](https://qiita.com/opengl-8080/items/6ad642e0b016465891de)